### PR TITLE
chore: remove soable! proc macro

### DIFF
--- a/soavec/Cargo.toml
+++ b/soavec/Cargo.toml
@@ -13,5 +13,8 @@ soavec_derive = { path = "../soavec_derive", optional = true }
 [dev-dependencies]
 soavec_derive = { version = "0.1.0", path = "../soavec_derive" }
 
+# This cfg cannot be enabled, but it still forces Cargo to keep soavec_derive's
+# version in lockstep with soavec's, even if someone depends on the two crates
+# separately with soavec's "derive" feature disabled.
 [target.'cfg(any())'.dependencies]
 soavec_derive = { version = "=0.1.0", path = "../soavec_derive" }

--- a/soavec_derive/src/soable.rs
+++ b/soavec_derive/src/soable.rs
@@ -43,7 +43,7 @@ pub fn expand_derive_soable(input: DeriveInput) -> syn::Result<TokenStream> {
 
     let type_params = generics.type_params().collect::<Vec<_>>();
     let lifetime_params = generics.lifetimes().collect::<Vec<_>>();
-    
+
     let has_type_generics = !type_params.is_empty();
     let has_lifetime_generics = !lifetime_params.is_empty();
 
@@ -272,7 +272,7 @@ mod tests {
         let result_str = result.to_string();
 
         assert!(result_str.contains("'a : 'soa"));
-        
+
         assert!(result_str.contains("& 'soa & 'a str"));
         assert!(result_str.contains("& 'soa u32"));
     }
@@ -280,8 +280,8 @@ mod tests {
     #[test]
     fn test_complex_generics() {
         let input: DeriveInput = syn::parse_quote! {
-            struct ComplexStruct<'a, 'b, T, U> 
-            where 
+            struct ComplexStruct<'a, 'b, T, U>
+            where
                 T: Clone,
                 U: Default
             {
@@ -295,10 +295,10 @@ mod tests {
         let result_str = result.to_string();
 
         assert!(result_str.contains("< 'soa , 'a , 'b , T , U >"));
-        
+
         assert!(result_str.contains("'a : 'soa"));
         assert!(result_str.contains("'b : 'soa"));
-        
+
         assert!(result_str.contains("T : Clone"));
         assert!(result_str.contains("U : Default"));
     }

--- a/soavec_derive/tests/integration.rs
+++ b/soavec_derive/tests/integration.rs
@@ -50,10 +50,10 @@ fn test_generic_struct() {
 
     let generic = GenericStruct {
         first: "hello",
-        second: 3.14,
+        second: 3.21,
     };
     let tuple = SoAble::into_tuple(generic);
-    assert_eq!(tuple, ("hello", 3.14));
+    assert_eq!(tuple, ("hello", 3.21));
 
     let back = GenericStruct::from_tuple(("world", 2.71));
     assert_eq!(back.first, "world");


### PR DESCRIPTION
Also added SoATuple support for up to 5 elements.