### PR TITLE
fix: rename len to __soa_len to avoid field name conflicts

### DIFF
--- a/soavec_derive/src/soable.rs
+++ b/soavec_derive/src/soable.rs
@@ -186,11 +186,11 @@ pub fn expand_derive_soable(input: DeriveInput) -> syn::Result<TokenStream> {
                 value: <Self::TupleRepr as soavec::SoATuple>::Pointers,
                 len: u32,
             ) -> Self::Slice<'soa> {
-                let len = len as usize;
+                let __soa_len = len as usize;
                 let (#(#field_names),*) = value;
                 unsafe {
                     #slice_struct_name {
-                        #(#field_names: core::slice::from_raw_parts(#field_names.as_ptr(), len)),*
+                        #(#field_names: core::slice::from_raw_parts(#field_names.as_ptr(), __soa_len)),*
                     }
                 }
             }
@@ -200,11 +200,11 @@ pub fn expand_derive_soable(input: DeriveInput) -> syn::Result<TokenStream> {
                 value: <Self::TupleRepr as soavec::SoATuple>::Pointers,
                 len: u32,
             ) -> Self::SliceMut<'soa> {
-                let len = len as usize;
+                let __soa_len = len as usize;
                 let (#(#field_names),*) = value;
                 unsafe {
                     #slice_mut_struct_name {
-                        #(#field_names: core::slice::from_raw_parts_mut(#field_names.as_ptr(), len)),*
+                        #(#field_names: core::slice::from_raw_parts_mut(#field_names.as_ptr(), __soa_len)),*
                     }
                 }
             }

--- a/soavec_derive/tests/integration.rs
+++ b/soavec_derive/tests/integration.rs
@@ -22,6 +22,13 @@ struct GenericStruct<T, U> {
 #[derive(SoAble)]
 struct TupleStruct(u32, f64, String);
 
+#[derive(SoAble)]
+struct StructWithLen {
+    a: usize,
+    // `len` should not overwrite in the macro
+    len: usize,
+}
+
 #[test]
 fn test_derive_compiles() {
     // If this compiles, the derive macro worked
@@ -75,4 +82,17 @@ fn test_tuple_struct() {
     assert_eq!(back.0, 42);
     assert_eq!(back.1, 2.71);
     assert_eq!(back.2, "hello".to_string());
+}
+
+#[test]
+fn test_struct_with_len_field() {
+    use soavec::SoAble;
+
+    let value = StructWithLen { a: 5, len: 8 };
+    let tuple = SoAble::into_tuple(value);
+    assert_eq!(tuple, (5, 8));
+
+    let back = StructWithLen::from_tuple((9, 12));
+    assert_eq!(back.a, 9);
+    assert_eq!(back.len, 12);
 }


### PR DESCRIPTION
## Problem

The argument `len` could be overwritten by a field named `len`.

## Solution

Rename the argument `len` to `__soa_len` before unpacking the fields. We can also prohibit the use of a field named `__soa_len` to avoid `__soa_len` also being overwritten, but I don't believe this is a very common name for a field.

Closes #26

